### PR TITLE
feat: distinction between production and development envs

### DIFF
--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -11,6 +11,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    environment: development
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -2,7 +2,10 @@ name: Build Strapi and Deploy to Cloud Run
 
 on:
   push:
-    branches: [master, develop]
+    branches:
+      - master
+      - develop
+      - feat/new-prod-environment
 
 jobs:
   deploy:

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -2,16 +2,17 @@ name: Build Strapi and Deploy to Cloud Run
 
 on:
   push:
-    branches:
-      - master
-      - develop
-      - feat/new-prod-environment
+    tags:
+      - production/*
+      - prod/*
+      - development/*
+      - dev/*
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'development' }}
+    environment: ${{ startsWith(github.ref, 'refs/tags/prod') && 'production' || 'development' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -2,13 +2,7 @@ name: Build Strapi and Deploy to Cloud Run
 
 on:
   push:
-    branches: [ "master" ]
-
-env:
-  PROJECT_ID: circl-backend
-  GAR_LOCATION: europe-west3
-  SERVICE: strapi
-  REGION: europe-west3
+    branches: [master, develop]
 
 jobs:
   deploy:
@@ -35,12 +29,12 @@ jobs:
         with:
           username: _json_key
           password: ${{ secrets.GCP_KEY }}
-          registry: ${{ env.GAR_LOCATION }}-docker.pkg.dev
+          registry: ${{ vars.GAR_LOCATION }}-docker.pkg.dev
 
       - name: Build and Push Container
         run: |-
-          docker build -t "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE }}:${{ github.sha }}" .
-          docker push "${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE }}:${{ github.sha }}"
+          docker build -t "${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }}" .
+          docker push "${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }}"
 
       - name: Deploy to Cloud Run
-        run: gcloud run deploy ${{ env.SERVICE }} --image ${{ env.GAR_LOCATION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/cloud-run-source-deploy/${{ env.SERVICE }}:${{ github.sha }} --region ${{ env.REGION }} --platform managed --allow-unauthenticated
+        run: gcloud run deploy ${{ vars.SERVICE }} --image ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }} --region ${{ vars.REGION }} --platform managed --allow-unauthenticated

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -41,4 +41,10 @@ jobs:
           docker push "${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }}"
 
       - name: Deploy to Cloud Run
-        run: gcloud run deploy ${{ vars.SERVICE }} --image ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }} --region ${{ vars.REGION }} --platform managed --allow-unauthenticated
+        run: |
+          gcloud run deploy \
+            --image ${{ vars.GAR_LOCATION }}-docker.pkg.dev/${{ vars.PROJECT_ID }}/cloud-run-source-deploy/${{ vars.SERVICE }}:${{ github.sha }} \
+            --region ${{ vars.REGION }} \
+            --platform managed \
+            --allow-unauthenticated \
+            ${{ vars.SERVICE }}

--- a/.github/workflows/google-cloudrun-docker.yml
+++ b/.github/workflows/google-cloudrun-docker.yml
@@ -11,7 +11,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    environment: development
+    environment: ${{ github.ref == 'refs/heads/master' && 'production' || 'development' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/config/server.ts
+++ b/config/server.ts
@@ -1,7 +1,7 @@
 export default ({ env }) => ({
   host: env('HOST', '0.0.0.0'),
   port: env.int('PORT', 1337),
-  url: 'https://strapi-hwnuo7l2pa-ey.a.run.app/',
+  url: env('URL', ''),
   app: {
     keys: env.array('APP_KEYS'),
   },


### PR DESCRIPTION
## Tasks
Resolves #3
- [x] Create 2 environments in the repository: `development` & `production`
- [x] Update the GitHub Actions workflow to get variables from the environment instead of hard-coded values
- [x] Update the GitHub Actions workflow to be triggered by tag instead of push on the main branch
- [x] Target the environment `production` if the tag starts with `prod` else target environment `development`
- [x] Manually create a database `circl_strapi_dev`
- [x] Manually create a service `circl-strapi-dev` with the same environment variables than `strapi` except for the database name
- [x] Update the roles associated to the service account `service-account-strapi` in order to give admin role on Cloud Run (⚠️ this permission is too broad but adding IAM condition didn't work)
- [x] Add the environment variable `URL` in services `strapi` and `circl-strapi-dev`