### PR TITLE
chore: upgrade `strapi-ulid` to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "strapi-plugin-config-sync": "^1.2.3",
     "strapi-plugin-import-export-entries": "^1.22.1",
     "strapi-plugin-multi-select": "^1.2.2",
-    "strapi-ulid": "0.1.3",
+    "strapi-ulid": "^0.1.5",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5677,7 +5677,7 @@ __metadata:
     strapi-plugin-config-sync: "npm:^1.2.3"
     strapi-plugin-import-export-entries: "npm:^1.22.1"
     strapi-plugin-multi-select: "npm:^1.2.2"
-    strapi-ulid: "npm:0.1.3"
+    strapi-ulid: "npm:0.1.5"
     styled-components: "npm:^5.2.1"
     typescript: "npm:^5.2.2"
   languageName: unknown
@@ -14572,14 +14572,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strapi-ulid@npm:0.1.3":
-  version: 0.1.3
-  resolution: "strapi-ulid@npm:0.1.3"
+"strapi-ulid@npm:0.1.5":
+  version: 0.1.5
+  resolution: "strapi-ulid@npm:0.1.5"
   dependencies:
     ulid: "npm:^2.3.0"
   peerDependencies:
     "@strapi/strapi": ^4.9.2
-  checksum: 10/90ab02d3fa876e6fd7eb8dc96c33b57cec91b7b09fbc585e3f4af7ee069240022d78f3ca500f403f18a173207e17316a3aeba6a4482e0b7a54f9e8d3a948beeb
+  checksum: 10/23bb8536f9620837680f01e77dcd9b8a9ce91294a75c24e36f8e4662970ba416770e313e53c8b63fd257abfdc41e26330552e5d716172531fca4ab9d66ca8553
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The new version 0.1.5 of `strapi-ulid` contains all the built JavaScript files, which was not the case with version 0.1.4 (modification done by the package maintainer after I opened the issue 8 in [soranoo/strapi-ulid](https://github.com/soranoo/strapi-ulid#readme).