### PR TITLE
fix: `loyalty` → `immediate` in `loyalty_type` enum

### DIFF
--- a/src/api/seller-product-detail/content-types/seller-product-detail/schema.json
+++ b/src/api/seller-product-detail/content-types/seller-product-detail/schema.json
@@ -64,8 +64,8 @@
     "loyalty_type": {
       "type": "enumeration",
       "enum": [
-        "loyalty",
         "cashback",
+        "immediate",
         "none"
       ]
     }


### PR DESCRIPTION
## What's done?
- [x] Rename enum option `loyalty` into `immedidate` in choices for the field `seller_product_detail.loyalty_type`